### PR TITLE
Add podcast owner field due to register google podcast manager

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -22,6 +22,10 @@ description = "Android を中心として Native アプリ界隈を取り巻く�
 author = "OUTER HEAVEN PROJECT"
 image = "images/ohfm.png"
 
+[params.podcast.owner]
+name = "OUTER HEAVEN PROJECT"
+email = "outer-heaven-project@googlegroups.com"
+
 [params.podcast.category]
 name = "Technology"
 


### PR DESCRIPTION
Google Podcast Managerへの登録にはowner情報（とりわけメールアドレス）が必要になる
- https://support.google.com/podcast-publishers/answer/9476656#get_on_google

てなわけで登録する。幸いzen themeにはowner情報に対応していた。ヤッピー

#1 がマージされてからマージしてよい